### PR TITLE
Avoid race conditions for resource monitoring.

### DIFF
--- a/container/container.cc
+++ b/container/container.cc
@@ -1,8 +1,11 @@
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <signal.h>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -16,11 +19,14 @@
 #include "util/time.h"
 
 using std::atomic;
-using std::chrono::steady_clock;
+using namespace std::chrono_literals;
+using std::condition_variable;
 using std::endl;
 using std::make_unique;
+using std::mutex;
 using std::string;
 using std::thread;
+using std::unique_lock;
 using std::vector;
 
 namespace omogenexec {
@@ -68,15 +74,12 @@ void Container::killInit() {
 
 int Container::waitInit() {
     int waitStatus = 0;
-    while (true) {
-        int pid = waitpid(initPid, &waitStatus, 0);
-        if (pid == -1) {
-            if (errno == EINTR) {
-                continue;
-            }
-            OE_FATAL("waitpid");
+    int pid = waitpid(initPid, &waitStatus, 0);
+    if (pid == -1) {
+        if (errno == EINTR) {
+            return -1;
         }
-        break;
+        OE_FATAL("waitpid");
     }
     // In case the container is actually used and thus waited for here, we do not want to
     // kill and wait for the process again when we destroy the container, so we mark that
@@ -95,36 +98,91 @@ static void setTermination(Termination* termination, int waitStatus) {
     } else assert(false && "Invalid exit status");
 }
 
+struct MonitorState {
+    Container *container;
+    atomic<bool> isDead;
+    atomic<bool> shouldKill;
+    bool waitReady;
+    mutex lock;
+    condition_variable waitCv;
+    int waitStatus;
+
+    MonitorState(Container* cont) : container(cont), isDead(false), shouldKill(false), waitReady(false), waitStatus(0) {}
+};
 
 ExecuteResponse Container::monitorInit(const ResourceLimits& limits) {
     ExecuteResponse response;
     Stopwatch watch;
-    atomic<bool> isDead(false);
-    // We monitor whether init has exceeded any of the resources we cannot limit explicitly
-    // in a separate thread, since we need also need to wait for the process in case it 
-    // exits normally.
-    thread resourceMonitor([&](){
-#define CHECK_LIM(current, limit, name) \
-    if ((current) > (limit)) { \
-        OE_LOG(TRACE) << name << " exceeded" << endl; \
-        killInit(); \
-        break; \
-    }
-        while (!isDead) {
-            // Memory does not need to be monitored, since this is the only limit
-            // that the control groups can be limit by itself.
-            CHECK_LIM(cgroup->CpuUsed(), (long long)(limits.cputime() * 1000), "CPU");
-            CHECK_LIM(watch.millis(), (long long)(limits.walltime() * 1000), "Wall time");
-            CHECK_LIM(cgroup->DiskIOUsed(), limits.diskio(), "Disk IO");
-            const timespec pollSleep { 0, 5000000 }; // 5 milliseconds
-            nanosleep(&pollSleep, nullptr);
+    MonitorState monitorState(this);
+
+    // We keep one thread that only waits for the process to complete.
+    // We also let this thread be responsible for killing the process in case it exceeds
+    // its resource limits. This avoids races between killing the process and waiting for it,
+    // something that could otherwise result in us killing an unrelated process after the PID
+    // has been reused.
+    pthread_t waitThread;
+    errno = pthread_create(&waitThread, nullptr, [](void* arg) -> void* {
+        MonitorState *state = static_cast<MonitorState*>(arg);
+        // The resource monitor loop notifies us if we should kill init by giving us SIGALRM to interrupt our
+        // wait. We use a lock and flag to tell the monitor when we have set up our own signal handler to avoid
+        // getting such a signal before the handler is installed, otherwise we would get killed by the signal.
+        {
+            unique_lock<std::mutex> waitLock(state->lock);
+            struct sigaction action;
+            memset(&action, 0, sizeof(action));
+            action.sa_handler = [](int){};
+            sigaction(SIGALRM, &action, NULL);
+            state->waitReady = true;
         }
+        state->waitCv.notify_one();
+        while (true) {
+            if (state->shouldKill) {
+                state->container->killInit();
+            }
+            int waitStatus = state->container->waitInit();
+            if (waitStatus != -1) {
+                state->waitStatus = waitStatus;
+                break;
+            }
+        }
+        state->isDead = true;
+        // To avoid some latency, we wake the resource monitor up from its polling sleep
+        // whenever the process is dead.
+        state->waitCv.notify_one();
+        return nullptr;
+    }, &monitorState);
+    if (errno != 0) {
+        OE_FATAL("pthread_create");
+    }
+
+    // Wait for the waitThread to set up its signal handler
+    {
+        unique_lock<std::mutex> waitLock(monitorState.lock);
+        monitorState.waitCv.wait(waitLock, [&]{ return monitorState.waitReady; });
+    }
+
+    while (!monitorState.isDead) {
+#define CHECK_LIM(current, limit, name) \
+        if ((current) > (limit)) { \
+            OE_LOG(TRACE) << name << " exceeded" << endl; \
+            monitorState.shouldKill = true; \
+            pthread_kill(waitThread, SIGALRM); \
+            break; \
+        }
+        // Memory does not need to be monitored, since this is the only limit
+        // that the control groups can be limit by itself.
+        CHECK_LIM(cgroup->CpuUsed(), (long long)(limits.cputime() * 1000), "CPU");
+        CHECK_LIM(watch.millis(), (long long)(limits.walltime() * 1000), "Wall time");
+        CHECK_LIM(cgroup->DiskIOUsed(), limits.diskio(), "Disk IO");
+
+        unique_lock<std::mutex> timeoutLock(monitorState.lock);
+        monitorState.waitCv.wait_for(timeoutLock, 5ms, [&]{ return !monitorState.isDead; });
 #undef CHECK_LIM
-    });
-    int waitStatus = waitInit();
+    }
+    if ((errno = pthread_join(waitThread, nullptr)) != 0) {
+        OE_FATAL("pthread_join");
+    }
     long long elapsed = watch.millis();
-    isDead = true;
-    resourceMonitor.join();
 
     ExecutionResult *result = response.mutable_result();
     ResourceUsage *resourceUsage = result->mutable_resourceusage();
@@ -137,6 +195,9 @@ ExecuteResponse Container::monitorInit(const ResourceLimits& limits) {
     resourceUsage->set_diskio(diskIoKb);
 
     Termination *termination = result->mutable_termination();
+    // We do not want to do a call to mutable_resrouceexceeded() unless any resource actually was exceeded.
+    // This lets client test for the presence of resourceexceeded to determine if a resource was exceeded
+    // instead of checking each resource individually.
     if (cpuUsedMs > (long long)(limits.cputime() * 1000)) {
         termination->mutable_resourceexceeded()->set_cputime(true);
     }
@@ -149,10 +210,11 @@ ExecuteResponse Container::monitorInit(const ResourceLimits& limits) {
     if (diskIoKb > (long long)(limits.diskio())) {
         termination->mutable_resourceexceeded()->set_diskio(true);
     }
-    // We only set the normal termination cause in case we did not exceed any resource,
-    // since 
+    // We only want to set the normal termination cause in case we did not exceed any resource,
+    // since the termination does not have much meaning otherwise (it is essentially random depending on
+    // whether the process completed just before getting killed or not.
     if (!termination->has_resourceexceeded()) {
-        setTermination(result->mutable_termination(), waitStatus);
+        setTermination(termination, monitorState.waitStatus);
     }
     return response;
 }


### PR DESCRIPTION
It is possible that init finishes and successfully wait for the thread,
   and only then is killed by the resource monitor. In pathological
   cases, this might result in accidentally killing a new process which
   got a recycled pid.