### PR TITLE
Make bash scripts invariant to directory of execution

### DIFF
--- a/scripts/build/all.sh
+++ b/scripts/build/all.sh
@@ -1,2 +1,6 @@
 #!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 bazel build {admin,filehandler,frontend,localjudge,masterjudge,problemtools,runner,sandbox,schema,storage,util,vendor}/...

--- a/scripts/build/packages.sh
+++ b/scripts/build/packages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 bazel build {frontend,localjudge,masterjudge,sandbox}/deb/...
 mkdir -p builds
 

--- a/scripts/build/prod-packages.sh
+++ b/scripts/build/prod-packages.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 bazel build -c opt {frontend,localjudge,masterjudge,sandbox}/deb/...
 mkdir -p builds
 

--- a/scripts/deploy/all.sh
+++ b/scripts/deploy/all.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 scripts/build/packages.sh
 
 sudo dpkg -i builds/omogenjudge-sandbox-dev.deb

--- a/scripts/deploy/frontend.sh
+++ b/scripts/deploy/frontend.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 scripts/build/packages.sh
 
 sudo dpkg -i builds/omogenjudge-frontend-dev.deb

--- a/scripts/deploy/local.sh
+++ b/scripts/deploy/local.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 scripts/build/packages.sh
 
 sudo dpkg -i builds/omogenjudge-local-dev.deb

--- a/scripts/deploy/master.sh
+++ b/scripts/deploy/master.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 scripts/build/packages.sh
 
 sudo dpkg -i builds/omogenjudge-master-dev.deb

--- a/scripts/deploy/sandbox.sh
+++ b/scripts/deploy/sandbox.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+cd $SCRIPT_DIR/../../
+
 scripts/build/packages.sh
 
 sudo dpkg -i builds/omogenjudge-sandbox-dev.deb


### PR DESCRIPTION
Clarify that the build scripts has to be run from root directory