### PR TITLE
Early return empty problem list for empty filter.

### DIFF
--- a/storage/problems/list.go
+++ b/storage/problems/list.go
@@ -55,6 +55,9 @@ func List(ctx context.Context, args ListArgs, filter ListFilter) (models.Problem
 		filters++
 	}
 	if filter.Problems != nil {
+		if len(filter.Problems.ProblemID) == 0 {
+			return nil, nil
+		}
 		filters++
 	}
 	if filter.ContestID != 0 {


### PR DESCRIPTION
Currently this results in a "WHERE problem_id IN ()" query, which is
incorrect.

@Istlemin this should fix your issue.