### PR TITLE
Add an option to specify a problem source instead of author.

### DIFF
--- a/admin/addproblem/addproblem.go
+++ b/admin/addproblem/addproblem.go
@@ -251,6 +251,7 @@ func installProblem(path string) error {
 		Statements:     getStatements(problem.Statements),
 		License:        models.License(problem.Metadata.License.String()),
 		Author:         problem.Metadata.Author,
+		Source:         problem.Metadata.Source,
 		CurrentVersion: problemVersion,
 	}
 	if err := problems.CreateProblem(ctx, storageProblem); err != nil {

--- a/problemtools/api/problem.proto
+++ b/problemtools/api/problem.proto
@@ -27,6 +27,7 @@ message Metadata {
   Limits limits = 2;
   string author = 3;
   License license = 4;
+  string source = 5;
 }
 
 // A parsed problem statement, possibly in any language.

--- a/problemtools/problems/metadata_parse.go
+++ b/problemtools/problems/metadata_parse.go
@@ -24,6 +24,7 @@ type problemJudging struct {
 
 type problemMetadata struct {
 	Author  string
+	Source  string
 	License string
 	Judging problemJudging
 }
@@ -81,6 +82,7 @@ func parseMetadata(path string, reporter util.Reporter) (*toolspb.Metadata, erro
 			TimeLimitMultiplier: timeMultiplier,
 		},
 		Author:  md.Author,
+		Source:  md.Source,
 		License: lic,
 	}, nil
 }

--- a/problemtools/problems/metadata_verify.go
+++ b/problemtools/problems/metadata_verify.go
@@ -22,8 +22,8 @@ func verifyMetadata(problem *toolspb.Problem, reporter util.Reporter) error {
 		reporter.Err("No license set")
 	}
 
-	if problem.Metadata.Author == "" {
-		reporter.Err("No author set")
+	if problem.Metadata.Author == "" && problem.Metadata.Source == "" {
+		reporter.Err("No author or source set")
 	}
 
 	timeLimit := problem.Metadata.Limits.TimeLimitMs

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -31,6 +31,7 @@ CREATE TABLE problem(
 	problem_id SERIAL PRIMARY KEY,
 	short_name TEXT NOT NULL,
 	author TEXT NOT NULL,
+    source TEXT NOT NULL,
 	license TEXT NOT NULL,
 	current_version INTEGER
 );

--- a/storage/models/problems.go
+++ b/storage/models/problems.go
@@ -18,6 +18,7 @@ type Problem struct {
 	Author         string          `db:"author"`
 	License        License         `db:"license"`
 	CurrentVersion *ProblemVersion `db:"problem_version"`
+	Source         string          `db:"source"`
 }
 
 // localizedStatement returns the statement of a problem closest to the ones given in langs.

--- a/storage/problems/create.go
+++ b/storage/problems/create.go
@@ -102,10 +102,10 @@ func insertProblem(ctx context.Context, problem *models.Problem, tx *sqlx.Tx) er
 	return tx.QueryRowContext(ctx,
 		`
     INSERT INTO
-      problem(short_name, author, license)
-    VALUES($1, $2, $3)
+      problem(short_name, author, source, license)
+    VALUES($1, $2, $3, $4)
     RETURNING problem_id`,
-		problem.ShortName, problem.Author, problem.License).Scan(&problem.ProblemID)
+		problem.ShortName, problem.Author, problem.Source, problem.License).Scan(&problem.ProblemID)
 }
 
 func setCurrentVersion(ctx context.Context, problem *models.Problem, tx *sqlx.Tx) error {

--- a/storage/problems/update.go
+++ b/storage/problems/update.go
@@ -17,10 +17,11 @@ func UpdateProblem(ctx context.Context, problem *models.Problem) error {
 			UPDATE problem
 			SET 
 			    author = $2,
-			    license = $3
+			    source = $3,
+			    license = $4
 			WHERE short_name = $1
 			RETURNING problem_id`
-		if err := tx.QueryRowContext(ctx, query, problem.ShortName, problem.Author, problem.License).Scan(&problem.ProblemID); err != nil {
+		if err := tx.QueryRowContext(ctx, query, problem.ShortName, problem.Author, problem.Source, problem.License).Scan(&problem.ProblemID); err != nil {
 			return fmt.Errorf("failed update problem query: %v", err)
 		}
 


### PR DESCRIPTION
This will be used for problems where we only need to specify a source as
attribution rather than the author.