### PR TITLE
Add support for downloadable attachments.

### DIFF
--- a/frontend/problems/file.go
+++ b/frontend/problems/file.go
@@ -13,7 +13,6 @@ import (
 func FileHandler(r *request.Request) (request.Response, error) {
 	vars := mux.Vars(r.Request)
 	shortName := vars[paths.ProblemNameArg]
-	lang := vars[paths.ProblemLangArg]
 	path := vars[paths.ProblemFileArg]
 	problem, err := getProblemIfVisible(r, vars[paths.ProblemNameArg], problems.ListArgs{})
 	if err != nil {
@@ -23,7 +22,7 @@ func FileHandler(r *request.Request) (request.Response, error) {
 		return request.NotFound(), nil
 	}
 
-	file, err := problems.GetStatementFile(r.Request.Context(), shortName, lang, path)
+	file, err := problems.GetStatementFile(r.Request.Context(), shortName, path)
 	if err == sql.ErrNoRows {
 		return request.NotFound(), nil
 	}
@@ -31,5 +30,8 @@ func FileHandler(r *request.Request) (request.Response, error) {
 		return nil, err
 	}
 	content, err := file.Content.FileData()
+	if file.Attachment {
+		r.Writer.Header().Set("Content-Disposition", "attachment")
+	}
 	return request.RawBytes(content), err
 }

--- a/frontend/request/request.go
+++ b/frontend/request/request.go
@@ -161,12 +161,10 @@ func (req *Request) Write(w http.ResponseWriter) {
 		if _, err := w.Write([]byte(r.Content)); err != nil {
 			logger.Errorf("Failed writing content: %v", err)
 		}
-		w.WriteHeader(r.Code())
 	case *rawBytesResponse:
 		if _, err := w.Write(r.Content); err != nil {
 			logger.Errorf("Failed writing content: %v", err)
 		}
-		w.WriteHeader(r.Code())
 	case *templateResponse:
 		err := templates.ExecuteTemplates(w, r.Name,
 			struct {

--- a/frontend/server/router.go
+++ b/frontend/server/router.go
@@ -23,8 +23,8 @@ func configureRouter() *mux.Router {
 	r.HandleFunc("/problems", plain(problems.ListHandler)).Name(paths.ProblemList)
 	r.HandleFunc(fmt.Sprintf("/problems/{%s}", paths.ProblemNameArg), plain(problems.ViewHandler)).Name(paths.Problem)
 	r.HandleFunc(fmt.Sprintf("/problems/{%s}/submit", paths.ProblemNameArg), plain(problems.SubmitHandler)).Name(paths.SubmitProblem)
-	r.HandleFunc(fmt.Sprintf("/problems/{%s}/{%s}/{%s}",
-		paths.ProblemNameArg, paths.ProblemLangArg, paths.ProblemFileArg),
+	r.HandleFunc(fmt.Sprintf("/problems/{%s}/{%s:.*}",
+		paths.ProblemNameArg, paths.ProblemFileArg),
 		plain(problems.FileHandler)).Name(paths.ProblemFile)
 	r.HandleFunc(fmt.Sprintf("/submissions/{%s}", paths.SubmissionIdArg), plain(submissions.ViewHandler)).Name(paths.Submission)
 	r.HandleFunc(fmt.Sprintf("/users/{%s}", paths.UserNameArg), plain(users.ViewHandler)).Name(paths.User)

--- a/frontend/templates/problems/view.tpl
+++ b/frontend/templates/problems/view.tpl
@@ -24,8 +24,6 @@
                 </tr>
               </table>
             </div>
-            <strong>
-            </strong>
             <div class="mdl-card__actions mdl-card--border">
               {{ if not .C.User }}
                 <a class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect" href="{{ path "login" }}">
@@ -40,7 +38,14 @@
               {{ end }}
             </div>
           </div>
-
+          {{ if .D.Problem.StatementFiles }}
+            <div class="mdl-card mdl-shadow--2dp" style="margin-top: 25px; padding: 10px 25px; width: auto; height: auto; min-height: 0">
+                <strong>Bifogade filer</strong>
+                {{ range .D.Problem.StatementFiles }}
+                  <a href="{{ path "problem_file" "problem_name" $.D.Problem.ShortName "problem_file_name" .Path }}">{{ .Path }}</a>
+                {{ end }}
+            </div>
+          {{ end }}
         </div>
         <div class="mdl-shadow--2dp mdl-cell mdl-cell--7-col" style="padding: 0 25px">
           <h1 class="display">{{ .D.Problem.LocalizedTitle $.C.Locales }}</h1>

--- a/problemtools/api/problem.proto
+++ b/problemtools/api/problem.proto
@@ -9,9 +9,7 @@ import "runner/api/eval.proto";
 message Problem {
   // Metadata about the problem.
   Metadata metadata = 1;
-  // All statements that were present in the problem.
-  // They have no particular order.
-  repeated ProblemStatement statements = 2;
+  ProblemStatements statements = 2;
   // All test groups that were present in the problem.
   // They have no particular order.
   repeated TestGroup test_groups = 3;
@@ -30,6 +28,18 @@ message Metadata {
   string source = 5;
 }
 
+message ProblemStatements {
+  // All statements that were present in the problem.
+  // They have no particular order.
+  repeated ProblemStatement statements = 1;
+  // Files that should be made for inclusion in the problem statement.
+  // Mapping from public file path to the file path in the system containing the file.
+  map<string, string> statement_files = 2;
+  // Files that should be listed as attachments available for download.
+  // Mapping from public file path to the file path in the system containing the file.
+  map<string, string> attachments = 3;
+}
+
 // A parsed problem statement, possibly in any language.
 message ProblemStatement {
   // A language code, either just a language ("en") or a language with a
@@ -41,8 +51,6 @@ message ProblemStatement {
 
   // The parsed HTML of the problem statement.
   string statement_html = 3;
-
-  map<string, string> statement_files = 4;
 }
 
 // A test case group containing a set of testcases.

--- a/problemtools/problems/statement_markdown.go
+++ b/problemtools/problems/statement_markdown.go
@@ -53,7 +53,7 @@ func hasProblemMd(path string) (bool, error) {
 	return false, nil
 }
 
-func parseMarkdown(path string, problemName string, reporter util.Reporter) (*toolspb.ProblemStatement, error) {
+func parseMarkdown(path string, problemName string, statementFiles map[string]string, reporter util.Reporter) (*toolspb.ProblemStatement, error) {
 	dat, err := ioutil.ReadFile(filepath.Join(path, "problem.md"))
 	if err != nil {
 		return nil, err
@@ -89,13 +89,12 @@ func parseMarkdown(path string, problemName string, reporter util.Reporter) (*to
 	}
 
 	renderer := html.NewRenderer(opts)
-	statement_html := string(markdown.ToHTML(dat, nil, renderer))
+	statementHtml := string(markdown.ToHTML(dat, nil, renderer))
 
 	if title == "" {
 		reporter.Err("Statement for language %s had no title", lang)
 	}
 
-	otherFiles := make(map[string]string)
 	subFiles, err := listSubFiles(path)
 	if err != nil {
 		return nil, err
@@ -103,15 +102,14 @@ func parseMarkdown(path string, problemName string, reporter util.Reporter) (*to
 	for _, filePath := range subFiles {
 		name := filepath.Base(filePath)
 		if name != "problem.md" && filePath != path {
-			otherFiles[filepath.Base(filePath)] = filePath
+			statementFiles[filepath.Base(path)+"/"+filepath.Base(filePath)] = filePath
 		}
 	}
 
 	return &toolspb.ProblemStatement{
-		LanguageCode:   lang,
-		Title:          title,
-		StatementHtml:  statement_html,
-		StatementFiles: otherFiles,
+		LanguageCode:  lang,
+		Title:         title,
+		StatementHtml: statementHtml,
 	}, nil
 
 }

--- a/problemtools/problems/statement_verify.go
+++ b/problemtools/problems/statement_verify.go
@@ -8,10 +8,11 @@ import (
 )
 
 func verifyStatements(problem *toolspb.Problem, reporter util.Reporter) error {
-	if len(problem.Statements) == 0 {
+	statements := problem.Statements.Statements
+	if len(statements) == 0 {
 		reporter.Err("Problem had no statements")
 	}
-	for _, statement := range problem.Statements {
+	for _, statement := range statements {
 		if statement.Title == "" {
 			reporter.Err("Statement for language %s had no title", statement.LanguageCode)
 		}

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -76,12 +76,11 @@ CREATE TABLE problem_statement(
 GRANT ALL ON problem_statement TO omogenjudge;
 
 CREATE TABLE problem_statement_file(
-	problem_id INTEGER NOT NULL,
-	language TEXT NOT NULL,
-	FOREIGN KEY(problem_id, language) REFERENCES problem_statement ON DELETE CASCADE,
+	problem_id INTEGER NOT NULL REFERENCES problem_statement ON DELETE CASCADE,
 	file_path TEXT NOT NULL,
 	file_hash VARCHAR(256) NOT NULL REFERENCES stored_file,
-	PRIMARY KEY(problem_id, language, file_path)
+	attachment BOOLEAN NOT NULL,
+	PRIMARY KEY(problem_id, file_path)
 );
 
 GRANT ALL ON problem_statement_file TO omogenjudge;

--- a/storage/models/problems.go
+++ b/storage/models/problems.go
@@ -19,6 +19,7 @@ type Problem struct {
 	License        License         `db:"license"`
 	CurrentVersion *ProblemVersion `db:"problem_version"`
 	Source         string          `db:"source"`
+	StatementFiles []*ProblemStatementFile
 }
 
 // localizedStatement returns the statement of a problem closest to the ones given in langs.
@@ -62,17 +63,15 @@ type ProblemStatement struct {
 	Title string `db:"title"`
 	// The HTML template of the statement.
 	HTML string `db:"html"`
-
-	Files []*ProblemStatementFile
 }
 
 // A ProblemStatementFile is a file that is used by the text statement of a problem.
 type ProblemStatementFile struct {
 	ProblemID int32 `db:"problem_id"`
 	// The tag of the language that the statement is written in.
-	Language string      `db:"language"`
-	Path     string      `db:"file_path"`
-	Content  *StoredFile `db:"content"`
+	Path       string      `db:"file_path"`
+	Attachment bool        `db:"attachment"`
+	Content    *StoredFile `db:"content"`
 }
 
 // ProblemMap maps problem IDs to problems.

--- a/storage/problems/update.go
+++ b/storage/problems/update.go
@@ -41,6 +41,9 @@ func UpdateProblem(ctx context.Context, problem *models.Problem) error {
 		if _, err := tx.ExecContext(ctx, "DELETE FROM problem_statement_file WHERE problem_id = $1", problem.ProblemID); err != nil {
 			return err
 		}
+		if err := insertStatementFiles(ctx, problem, tx); err != nil {
+			return err
+		}
 		for _, s := range problem.Statements {
 			s.ProblemID = problem.ProblemID
 			if err := insertStatement(ctx, s, tx); err != nil {


### PR DESCRIPTION
Add support for an 'attachments' folder that files can be placed in to
appear as downloadable on problem pages.

Also removes the explicit "language" flag on the statement file table,
since it is unncessary.